### PR TITLE
this adds a userId reader

### DIFF
--- a/Application/src/main/java/com/proxy/api/gson/RealmUserTypeAdapter.java
+++ b/Application/src/main/java/com/proxy/api/gson/RealmUserTypeAdapter.java
@@ -43,12 +43,12 @@ public class RealmUserTypeAdapter extends com.google.gson.TypeAdapter<RealmUser>
 
             switch (reader.nextName()) {
                 case "userId":
-                    user.setUserId(reader.nextString());
+                    user.setUserId(readUserId(reader));
                     break;
-                case "firstName":
+                case "first":
                     user.setFirstName(reader.nextString());
                     break;
-                case "lastName":
+                case "last":
                     user.setLastName(reader.nextString());
                     break;
                 case "email":
@@ -105,6 +105,27 @@ public class RealmUserTypeAdapter extends com.google.gson.TypeAdapter<RealmUser>
         }
         reader.endObject();
         return channel;
+    }
+
+    public String readUserId(JsonReader r) throws IOException {
+        String res = null;
+        r.beginObject();
+        while(r.hasNext()){
+            switch(r.nextName()) {
+                case "value":
+                   res = r.nextString();
+                    break;
+                default:
+                    r.skipValue();
+                    break;
+            }
+        }
+
+        if(res == null){
+            throw new IOException("Invalid Json");
+        } else {
+            return res;
+        }
     }
 
     /**


### PR DESCRIPTION
We need to make sure the serialization between Web & Droid matches. This is the first step.

I'm passing around the userId as a separate type just to keep things safe. That could be overkill though, so I'm not opposed to ripping it out if need be.
